### PR TITLE
add asterisks to ST members

### DIFF
--- a/src/routes/lib/bar.svelte
+++ b/src/routes/lib/bar.svelte
@@ -68,7 +68,7 @@
         {#if user}
             <!-- svelte-ignore a11y-missing-attribute -->
             <li><a href="/users/{user.username}"><img src="https://cdn2.scratch.mit.edu/get_image/user/{user.id}_90x90.png" style={width > 5 ? "width: 2em; height: 2em;" : "display: none;"}></a></li>
-            <li class="username"><a href="/users/{user.username}"><nobr>{user.username}</nobr></a></li>
+            <li class="username"><a href="/users/{user.username}"><nobr>{user.username}{user.status == "Scratch Team" ? "*" : ""}</nobr></a></li>
             <li class="posts">
                 <a href="/users/{user.username}" style="font-weight: bold;">{posts}</a>
                 {#if barWidth > 12 && $cat != "total"}

--- a/src/routes/users/[slug].svelte
+++ b/src/routes/users/[slug].svelte
@@ -119,7 +119,7 @@
 		<ul class="info-container">
 			<li class="username">
 				{#if user}
-				<a href="/users/{user.username}"><nobr>{user.username}</nobr></a>
+				<a href="/users/{user.username}"><nobr>{user.username}{user.status == "Scratch Team" ? "*" : ""}</nobr></a>
 				{:else}
 				<a href="/users/{slug}"><nobr>{slug}</nobr></a>
 				{/if}


### PR DESCRIPTION
For Scratch comments, ST members have asterisks next to their name, and on the forums it displays "Scratch Team", so I added an asterisk next to ST member names for the leaderboard and on individual user pages

ScratchDB reports this data in requests already done so no extra requests are made

![image](https://user-images.githubusercontent.com/14064434/135864907-2f5eebc2-27b9-4ace-a360-95daf8a4176c.png)
